### PR TITLE
[TASK] Add escapeHtml() to getLatestNotice, adjust to Magento Core

### DIFF
--- a/src/app/design/adminhtml/default/default/template/notification_advanced/toolbar.phtml
+++ b/src/app/design/adminhtml/default/default/template/notification_advanced/toolbar.phtml
@@ -61,7 +61,7 @@
         <strong class="label">
     <?php endif; ?>
 
-    <?php echo $this->__('Latest Message:') ?></strong> <?php echo $this->getLatestNotice() ?>
+    <?php echo $this->__('Latest Message:') ?></strong> <?php echo $this->escapeHtml($this->getLatestNotice()) ?>
     <?php if (!empty($latestNoticeUrl)): ?>
         <a href="<?php echo $latestNoticeUrl ?>" onclick="this.target='_blank';"><?php echo $this->__('Read details') ?></a>
     <?php endif; ?>


### PR DESCRIPTION
Noticed after running the latest 1.9.3.7 update. There are also some other things commented out but I guess that's not too big of a deal:

![image](https://user-images.githubusercontent.com/2085721/34574456-bee19c52-f177-11e7-9f2b-ea0f2de4aaad.png)